### PR TITLE
fix: remove return res.cookies

### DIFF
--- a/backend/src/middlewares/setLangCookie.ts
+++ b/backend/src/middlewares/setLangCookie.ts
@@ -2,6 +2,6 @@ import { Request, Response, NextFunction } from "express";
 
 
 export function setLangCookie(req: Request, res: Response, next: NextFunction) {
-  if (!("lang" in req.cookies)) return res.cookie("lang", "pt-BR");
+  if (!("lang" in req.cookies)) res.cookie("lang", "pt-BR");
   next();
 }


### PR DESCRIPTION
I removed the 'return' statement. This middleware adds an attribute to the response, rather than constituting the response itself.